### PR TITLE
Backport CI fix to next branch

### DIFF
--- a/.github/workflows/test-contract.yml
+++ b/.github/workflows/test-contract.yml
@@ -15,50 +15,39 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  setup-environment:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Set up environment
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y curl
-
-  sozo-test:
-    needs: [setup-environment]
+  scarb-test:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
-      - name: Extract dojo version
-        run: |
-          DOJO_VERSION=$(grep '^dojo ' .tool-versions | awk '{print $2}')
-          echo "DOJO_VERSION=$DOJO_VERSION" >> "$GITHUB_ENV"
-
-      - name: Extract scarb version
+      - name: Extract versions
         run: |
           SCARB_VERSION=$(grep '^scarb ' .tool-versions | awk '{print $2}')
           echo "SCARB_VERSION=$SCARB_VERSION" >> "$GITHUB_ENV"
+          SNFORGE_VERSION=$(grep '^starknet-foundry ' .tool-versions | awk '{print $2}')
+          echo "SNFORGE_VERSION=$SNFORGE_VERSION" >> "$GITHUB_ENV"
 
-      - name: Download Dojo release artifact
-        run: |
-          curl -L -o dojo-linux-x86_64.tar.gz https://github.com/dojoengine/dojo/releases/download/v${{ env.DOJO_VERSION }}/dojo_v${{ env.DOJO_VERSION }}_linux_amd64.tar.gz
-          tar -xzf dojo-linux-x86_64.tar.gz
-          sudo mv sozo /usr/local/bin/
+      - name: Cache Scarb
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/scarb
+          key: scarb-${{ env.SCARB_VERSION }}-${{ hashFiles('contracts/Scarb.lock') }}
 
       - name: Setup Scarb
         uses: software-mansion/setup-scarb@v1
         with:
           scarb-version: ${{ env.SCARB_VERSION }}
-      - name: Run Dojo Build
-        run: |
-          cd contracts && sozo build
+
+      - name: Install Starknet Foundry
+        uses: foundry-rs/setup-snfoundry@v3
+        with:
+          starknet-foundry-version: ${{ env.SNFORGE_VERSION }}
+
       - name: Run Tests
-        run: |
-          cd contracts && sozo test
+        run: cd contracts && scarb test
 
   scarb-fmt:
-    needs: [setup-environment]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,2 +1,2 @@
 scarb 2.13.1
-snforge 0.54.0
+starknet-foundry 0.53.0

--- a/contracts/Scarb.lock
+++ b/contracts/Scarb.lock
@@ -90,15 +90,15 @@ checksum = "sha256:bf799c794139837f397975ffdf6a7ed5032d198bbf70e87a8f44f144a9dfc
 
 [[package]]
 name = "snforge_scarb_plugin"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:6ffa10fe0ff525678138afd584fc2012e7b248f9c8e7b44aeae033cef3ee7826"
+checksum = "sha256:10444a0211c5cf460aba730703a48ed72876f68b283e3741059fc2552ce226db"
 
 [[package]]
 name = "snforge_std"
-version = "0.46.0"
+version = "0.53.0"
 source = "registry+https://scarbs.xyz/"
-checksum = "sha256:a4d4b4d3e8506a3907d1eabacb058c390aa13a70132f475cba5e3dcd7a60d0bb"
+checksum = "sha256:85dd728289a4903e0e6f87f9ab9d27350b883e781b238bb117e7ee995e257ee2"
 dependencies = [
  "snforge_scarb_plugin",
 ]

--- a/contracts/Scarb.toml
+++ b/contracts/Scarb.toml
@@ -20,7 +20,7 @@ death_mountain_beast = { git = "https://github.com/Provable-Games/death-mountain
 test = "snforge test"
 
 [dev-dependencies]
-snforge_std = "0.46.0"
+snforge_std = "0.53.0"
 
 [[target.starknet-contract]]
 build-external-contracts = ["beasts_nft::beasts_nft"] 
@@ -31,7 +31,7 @@ max-line-length = 120
 
 [tool.snforge]
 fork = [
-    { name = "mainnet", url = "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_8", block_id = { tag = "latest" } }
+    { name = "mainnet", url = "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_10", block_id = { tag = "latest" } }
 ]
 
 [profile.dev.cairo]

--- a/contracts/tests/test_summit.cairo
+++ b/contracts/tests/test_summit.cairo
@@ -418,12 +418,24 @@ fn test_set_start_timestamp() {
     let contract = declare("summit_systems").unwrap().contract_class();
     let owner = REAL_PLAYER();
     let start_timestamp = 9999999999_u64; // Future timestamp
-    let submission_blocks = 100_u64;
+    let summit_duration_blocks = 1000000_u64;
+    let summit_reward_amount = 0_u128;
+    let showdown_duration_seconds = 100_u64;
+    let showdown_reward_amount = 100_u128;
+    let beast_tokens_amount = 100_u128;
+    let beast_submission_blocks = 100_u64;
+    let beast_top_spots = 100_u32;
 
     let mut calldata = array![];
     calldata.append(owner.into());
     calldata.append(start_timestamp.into());
-    calldata.append(submission_blocks.into());
+    calldata.append(summit_duration_blocks.into());
+    calldata.append(summit_reward_amount.into());
+    calldata.append(showdown_duration_seconds.into());
+    calldata.append(showdown_reward_amount.into());
+    calldata.append(beast_tokens_amount.into());
+    calldata.append(beast_submission_blocks.into());
+    calldata.append(beast_top_spots.into());
     calldata.append(DUNGEON_ADDRESS().into());
     calldata.append(BEAST_ADDRESS().into());
     calldata.append(BEAST_DATA_ADDRESS().into());


### PR DESCRIPTION
## Summary
Cherry-pick of #40 to bring CI fixes to the `next` branch.

**Changes:**
- Migrate from sozo to scarb for build and tests
- Upgrade starknet-foundry to 0.53.0
- Fix snforge version extraction (uses `starknet-foundry` key)
- Optimize CI workflow (remove unnecessary jobs, add caching)
- Fix RPC URL version (v0_8 → v0_10)
- Add explicit type suffixes for type safety in tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)