### PR TITLE
Fix upgrade costs to match documentation

### DIFF
--- a/contracts/src/constants.cairo
+++ b/contracts/src/constants.cairo
@@ -14,6 +14,9 @@ pub const BEAST_MAX_BONUS_HEALTH: u16 = 2000;
 pub const BEAST_MAX_BONUS_LVLS: u16 = 40;
 pub const BEAST_MAX_ATTRIBUTES: u8 = 100;
 pub const MAX_REVIVAL_COUNT: u8 = 31;
+pub const SPECIALS_COST: u16 = 10;
+pub const DIPLOMACY_COST: u16 = 15;
+pub const WISDOM_COST: u16 = 20;
 pub const EIGHT_BITS_MAX: u8 = 255;
 pub const TOKEN_DECIMALS: u256 = 1_000_000_000_000_000_000;
 

--- a/contracts/src/systems/summit.cairo
+++ b/contracts/src/systems/summit.cairo
@@ -88,7 +88,8 @@ pub mod summit_systems {
     use starknet::{ClassHash, ContractAddress, get_block_number, get_block_timestamp, get_caller_address};
     use summit::constants::{
         BASE_REVIVAL_TIME_SECONDS, BEAST_MAX_ATTRIBUTES, BEAST_MAX_BONUS_HEALTH, BEAST_MAX_BONUS_LVLS,
-        BEAST_MAX_EXTRA_LIVES, DAY_SECONDS, EIGHT_BITS_MAX, MAX_REVIVAL_COUNT, MINIMUM_DAMAGE, TOKEN_DECIMALS, errors,
+        BEAST_MAX_EXTRA_LIVES, DAY_SECONDS, DIPLOMACY_COST, EIGHT_BITS_MAX, MAX_REVIVAL_COUNT, MINIMUM_DAMAGE,
+        SPECIALS_COST, TOKEN_DECIMALS, WISDOM_COST, errors,
     };
     use summit::erc20::interface::{SummitERC20Dispatcher, SummitERC20DispatcherTrait};
     use summit::interfaces::{
@@ -333,13 +334,13 @@ pub mod summit_systems {
             if stats.specials == 1 {
                 assert(beast.live.stats.specials == 0, 'Specials already unlocked');
                 beast.live.stats.specials = 1;
-                tokens_required += 1;
+                tokens_required += SPECIALS_COST;
             }
 
             if stats.wisdom == 1 {
                 assert(beast.live.stats.wisdom == 0, 'Wisdom already unlocked');
                 beast.live.stats.wisdom = 1;
-                tokens_required += 10;
+                tokens_required += WISDOM_COST;
             }
 
             if stats.diplomacy == 1 {
@@ -350,7 +351,7 @@ pub mod summit_systems {
                 self.diplomacy_beast.entry(specials_hash).entry(diplomacy_count).write(beast_token_id);
                 self.diplomacy_count.entry(specials_hash).write(diplomacy_count + 1);
                 beast.live.stats.diplomacy = 1;
-                tokens_required += 5;
+                tokens_required += DIPLOMACY_COST;
             }
 
             beast.live.stats.spirit += stats.spirit;


### PR DESCRIPTION
## Summary
- Fixes beast upgrade costs in `apply_stat_points` to match the external documentation at docs.provable.games/summit
- **Specials**: 1 → 10 Kill Tokens
- **Diplomacy**: 5 → 15 Kill Tokens  
- **Wisdom**: 10 → 20 Kill Tokens

## Changes
- Added named constants (`SPECIALS_COST`, `DIPLOMACY_COST`, `WISDOM_COST`) to `constants.cairo`
- Updated `apply_stat_points` in `summit.cairo` to use the constants

## Test plan
- [x] All 34 existing tests pass
- [x] `scarb fmt` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Defined standardized token costs for upgrading special abilities, diplomacy, and wisdom attributes in the Summit system.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->