### PR TITLE
Precompute combat specs and crit chances before battle loop

### DIFF
--- a/contracts/src/systems/summit.cairo
+++ b/contracts/src/systems/summit.cairo
@@ -815,6 +815,22 @@ pub mod summit_systems {
                 let mut critical_counter_attack_count = 0;
                 let mut critical_counter_attack_damage = 0;
 
+                // precompute combat specs and crit chances before battle loop
+                let attacker_has_specials = attacking_beast.live.stats.specials == 1;
+                let defender_has_specials = defending_beast.live.stats.specials == 1;
+
+                // combat specs for when attacking_beast attacks
+                let attacker_spec_as_attacker = attacking_beast.get_combat_spec(attacker_has_specials);
+                let defender_spec_when_attacked = defending_beast.get_combat_spec(attacker_has_specials);
+
+                // combat specs for when defending_beast counter-attacks
+                let defender_spec_as_attacker = defending_beast.get_combat_spec(defender_has_specials);
+                let attacker_spec_when_attacked = attacking_beast.get_combat_spec(defender_has_specials);
+
+                // precompute critical hit chances
+                let attacker_crit_chance = attacking_beast.crit_chance();
+                let defender_crit_chance = defending_beast.crit_chance();
+
                 // loop until the attacking beast is dead or the summit beast is dead
                 loop {
                     // if either beast is dead, break
@@ -831,7 +847,13 @@ pub mod summit_systems {
 
                     let (damage, attacker_crit_hit) = self
                         ._attack(
-                            attacking_beast, ref defending_beast, remaining_attack_potions, attacker_crit_hit_rnd, vrf,
+                            attacker_spec_as_attacker,
+                            defender_spec_when_attacked,
+                            ref defending_beast,
+                            remaining_attack_potions,
+                            attacker_crit_hit_rnd,
+                            attacker_crit_chance,
+                            vrf,
                         );
 
                     if attacker_crit_hit {
@@ -846,7 +868,15 @@ pub mod summit_systems {
 
                     if defending_beast.live.current_health != 0 {
                         let (damage, defender_crit_hit) = self
-                            ._attack(defending_beast, ref attacking_beast, diplomacy_bonus, defender_crit_hit_rnd, vrf);
+                            ._attack(
+                                defender_spec_as_attacker,
+                                attacker_spec_when_attacked,
+                                ref attacking_beast,
+                                diplomacy_bonus,
+                                defender_crit_hit_rnd,
+                                defender_crit_chance,
+                                vrf,
+                            );
 
                         if defender_crit_hit {
                             critical_counter_attack_count += 1;
@@ -976,28 +1006,31 @@ pub mod summit_systems {
             }
         }
 
-        /// @title attack
         /// @notice this function is used to process a beast attacking another beast
-        /// @param attacker the beast that is attacking
+        /// @param attacker_combat_spec precomputed combat spec for the attacker
+        /// @param defender_combat_spec precomputed combat spec for the defender
         /// @param defender a ref to the beast that is defending
+        /// @param attack_potions number of attack potions to use
+        /// @param critical_hit_rnd random number for critical hit calculation
+        /// @param critical_hit_chance precomputed critical hit chance for the attacker
+        /// @param vrf whether VRF is being used
         /// @return a tuple containing the combat result and a bool indicating if the defender died
         /// @dev this function only mutates the defender
         fn _attack(
             ref self: ContractState,
-            attacker: Beast,
+            attacker_combat_spec: CombatSpec,
+            defender_combat_spec: CombatSpec,
             ref defender: Beast,
             attack_potions: u8,
             critical_hit_rnd: u8,
+            critical_hit_chance: u8,
             vrf: bool,
         ) -> (u16, bool) {
-            let attacker_combat_spec = attacker.get_combat_spec(attacker.live.stats.specials == 1);
-            let defender_combat_spec = defender.get_combat_spec(attacker.live.stats.specials == 1);
             let minimum_damage = MINIMUM_DAMAGE;
 
             let attacker_strength = attack_potions;
             let defender_strength = 0;
 
-            let critical_hit_chance = attacker.crit_chance();
             if (critical_hit_chance > 0) {
                 assert(vrf, 'missing VRF seed');
             }


### PR DESCRIPTION
## Summary

- Optimizes the attack loop by computing combat specs and critical hit chances once before the battle starts, rather than recomputing them on every iteration
- The `get_combat_spec()` function includes `sqrt` calculations and `crit_chance()` includes lookup logic - both are now computed once before the loop instead of 2-4 times per iteration
- Added `test_attack_long_battle_gas_benchmark` test for gas comparison

## Gas Savings

| Test | Before | After | Savings |
|------|--------|-------|---------|
| `test_attack_basic` (1-2 iterations) | ~11.5M gas | ~11.3M gas | **213k (1.85%)** |
| `test_attack_long_battle_gas_benchmark` (50+ iterations) | ~87M gas | ~47M gas | **40M (46.2%)** |

## Test plan

- [x] `scarb test test_attack_basic` passes
- [x] `scarb test test_attack_long_battle_gas_benchmark` passes
- [x] All existing tests pass (network-dependent tests may have intermittent failures due to RPC availability)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized the battle attack system by precomputing combat specifications and critical hit chances before each battle loop, reducing redundant calculations and improving overall system performance and responsiveness.

* **Tests**
  * Added a comprehensive gas-benchmark test to measure and monitor system performance during extended battle scenarios with multiple rounds of combat engagement.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->