### PR TITLE
Fix Ekubo quote amounts > 999

### DIFF
--- a/client/src/api/ekubo.ts
+++ b/client/src/api/ekubo.ts
@@ -42,15 +42,16 @@ interface SwapCall {
 }
 
 export const getSwapQuote = async (
-  amount: number,
+  amount: bigint | string,
   token: string,
   otherToken: string
 ): Promise<SwapQuote> => {
   const maxRetries = 10;
+  const amountParam = typeof amount === "bigint" ? amount.toString() : amount;
 
   for (let attempt = 0; attempt < maxRetries; attempt++) {
     const response = await fetch(
-      `https://prod-api-quoter.ekubo.org/23448594291968334/${amount}/${token}/${otherToken}`
+      `https://prod-api-quoter.ekubo.org/23448594291968334/${amountParam}/${token}/${otherToken}`
     );
     const data = await response.json();
 

--- a/client/src/components/dialogs/MarketplaceModal.tsx
+++ b/client/src/components/dialogs/MarketplaceModal.tsx
@@ -221,6 +221,7 @@ export default function MarketplaceModal(props: MarketplaceModalProps) {
   }, [sellQuantities, tokenQuotes, activeTab]);
 
   const canAfford = selectedTokenData && totalTokenCost <= Number(selectedTokenData.rawBalance);
+  const toBaseUnits = (quantity: number) => BigInt(quantity) * 10n ** 18n;
 
   const fetchPotionQuote = useCallback(
     async (potionId: string, tokenSymbol: string, quantity: number) => {
@@ -251,7 +252,7 @@ export default function MarketplaceModal(props: MarketplaceModalProps) {
 
       try {
         const quote = await getSwapQuote(
-          -quantity * 1e18,
+          -toBaseUnits(quantity),
           currentNetworkConfig.tokens.erc20.find(token => token.name === potionId)?.address!,
           selectedTokenData.address
         );
@@ -315,7 +316,7 @@ export default function MarketplaceModal(props: MarketplaceModalProps) {
 
       try {
         const quote = await getSwapQuote(
-          quantity * 1e18,
+          toBaseUnits(quantity),
           potionAddress,
           receiveTokenData.address,
         );
@@ -459,7 +460,7 @@ export default function MarketplaceModal(props: MarketplaceModalProps) {
 
           if (!quote) {
             quote = await getSwapQuote(
-              -quantity * 1e18,
+              -toBaseUnits(quantity),
               potionAddress,
               selectedTokenData.address
             );
@@ -514,7 +515,7 @@ export default function MarketplaceModal(props: MarketplaceModalProps) {
 
           if (!quote) {
             quote = await getSwapQuote(
-              quantity * 1e18,
+              toBaseUnits(quantity),
               potionAddress,
               selectedReceiveTokenData.address,
             );

--- a/client/src/contexts/Statistics.tsx
+++ b/client/src/contexts/Statistics.tsx
@@ -62,7 +62,7 @@ export const StatisticsProvider = ({ children }: PropsWithChildren) => {
   };
 
   const fetchTokenPrice = async (token: any) => {
-    const swap = await getSwapQuote(-1e18, token.address, USDC_ADDRESS);
+    const swap = await getSwapQuote(-1n * 10n ** 18n, token.address, USDC_ADDRESS);
     setTokenPrices((prev) => ({ ...prev, [token.name]: ((swap.total * -1) / 1e18).toFixed(4) }));
   };
 


### PR DESCRIPTION
## Summary
- build quote amounts as bigint base units to avoid scientific notation in the Ekubo quoter URL
- accept bigint/string amounts in getSwapQuote
- update Marketplace buy/sell + stats quote callers

## Testing
- not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Enhanced numeric precision in swap quote calculations across all marketplace operations (buy, sell, and batch transactions).
  * Improved accuracy in transaction processing for more reliable valuations when handling large numbers.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->