### PR TITLE
Increase TERMINAL_BLOCK to 6000000

### DIFF
--- a/client/src/utils/networkConfig.ts
+++ b/client/src/utils/networkConfig.ts
@@ -34,7 +34,7 @@ export const NETWORKS = {
     manifest: manifest_mainnet,
     slot: "pg-mainnet-10",
     rpcUrl: "https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_9",
-    torii: "https://api.cartridge.gg/x/pg-temp/torii",
+    torii: "https://api.cartridge.gg/x/pg-mainnet-10/torii",
     subscriptionUrl: "https://api.cartridge.gg/x/summit-6/torii",
     tokens: {
       erc20: [


### PR DESCRIPTION
## Summary
- Increases `TERMINAL_BLOCK` from 5,000,000 to 6,000,000
- Extends the Final Showdown threshold to allow the game to continue in normal mode

## Test plan
- [ ] Verify the game no longer shows Final Showdown mode at current block
- [ ] Confirm `TERMINAL_BLOCK` is correctly set to 6,000,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated network service endpoint configuration to maintain connectivity
  * Adjusted game mechanics parameter limits

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->