### PR TITLE
Increase TERMINAL_BLOCK to 6000000

### DIFF
--- a/client/src/contexts/GameDirector.tsx
+++ b/client/src/contexts/GameDirector.tsx
@@ -26,7 +26,7 @@ export interface GameDirectorContext {
 }
 
 export const START_TIMESTAMP = 1760947200;
-export const TERMINAL_BLOCK = 5000000;
+export const TERMINAL_BLOCK = 6000000;
 
 const GameDirectorContext = createContext<GameDirectorContext>(
   {} as GameDirectorContext


### PR DESCRIPTION
## Summary
- Increases `TERMINAL_BLOCK` from 5,000,000 to 6,000,000
- Extends the Final Showdown threshold to allow the game to continue in normal mode

## Test plan
- [ ] Verify the game no longer shows Final Showdown mode at current block
- [ ] Confirm `TERMINAL_BLOCK` is correctly set to 6,000,000

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated game configuration value to enhance gameplay mechanics.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->