### PR TITLE
fix: reduce quest reward batch size to avoid L2Gas limit

### DIFF
--- a/client/src/components/ClaimRewardsButton.tsx
+++ b/client/src/components/ClaimRewardsButton.tsx
@@ -14,7 +14,7 @@ const survivorTokenIcon = '/images/survivor_token.png';
 
 const SKULL_LIMIT = 250;
 const CORPSE_LIMIT = 250;
-const QUEST_REWARD_LIMIT = 2450;
+const QUEST_REWARD_LIMIT = 900;
 const SUMMIT_REWARD_LIMIT = 295;
 
 interface ClaimState {


### PR DESCRIPTION
## Summary
- Reduced `QUEST_REWARD_LIMIT` from 2450 to 900 to prevent `claim_quest_rewards` transactions from exceeding the 1B max L2Gas limit

## Changes
- `client/src/components/ClaimRewardsButton.tsx`: `QUEST_REWARD_LIMIT` 2450 → 900

## Context
Users were getting reverted transactions when claiming quest rewards:
```
"Insufficient max L2Gas: max amount: 1000000000, actual used: 2669448960"
```

Each beast in the batch requires two external contract calls (`owner_of` + `get_beast`) at ~1.09M gas each. With 2450 beasts, that's ~2.67B gas — well over the 1B limit. At 900 beasts, the estimated gas is ~981M, safely under the limit. The existing batching loop handles splitting larger collections into multiple sequential transactions automatically.

## Testing
- Client builds cleanly with `pnpm build`

@codex review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Quest reward claiming now processes rewards in smaller batches, improving reliability and reducing the chance of timeouts or failures during large claim operations.
  * Users should experience more consistent claim behavior for large reward sets, with fewer interruptions and more dependable completion of multi-reward claims.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->