### PR TITLE
chore(codecov): expand ignore list for non-Cairo directories

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -15,10 +15,22 @@ coverage:
         threshold: 4%
 
 ignore:
+  # Test files — covered by test runner, not measured for coverage
   - "**/tests/**"
-  - "**/assets**"
-  - "dojo/"
+
+  # Non-Cairo directories — no testable contract source code
   - "client/"
+  - "api/"
+  - "indexer/"
+
+  # Infrastructure & configuration
+  - ".github/"
+  - ".devcontainer/"
+  - "data-snapshot/"
+
+  # Generated artifacts & non-source assets
+  - "**/assets/**"
+  - "contracts/gas_reports/"
 
 github_checks:
   annotations: false


### PR DESCRIPTION
## Summary
- Adds `api/`, `indexer/`, `.github/`, `.devcontainer/`, `data-snapshot/`, and `contracts/gas_reports/` to the codecov ignore list
- Organizes ignore entries into labeled categories (tests, non-Cairo dirs, infra/config, generated artifacts)
- Fixes the `**/assets**` glob to the more precise `**/assets/**`

These directories contain no testable Cairo contract source code (`contracts/src/` is the only coverage target) and were adding noise to coverage reports.

## Test plan
- [ ] Verify Codecov report on next push excludes the newly ignored paths
- [ ] Confirm `contracts/src/` files still appear in coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)