### PR TITLE
fix(client): remove fragile inline dev-mode parity assertion

### DIFF
--- a/client/src/utils/translation.ts
+++ b/client/src/utils/translation.ts
@@ -148,45 +148,6 @@ export function unpackLiveBeastStats(packedFelt: string): LiveBeastStats {
   };
 }
 
-const CROSS_LAYER_PARITY_PACKED =
-  "0x6dc75813f7e39148cb039612a721092075bcd153ade68b10000000067748580";
-const CROSS_LAYER_PARITY_EXPECTED: LiveBeastStats = {
-  token_id: 4242,
-  current_health: 1337,
-  bonus_health: 777,
-  bonus_xp: 12345,
-  attack_streak: 9,
-  last_death_timestamp: 1735689600,
-  revival_count: 17,
-  extra_lives: 3210,
-  summit_held_seconds: 654321,
-  spirit: 88,
-  luck: 199,
-  specials: true,
-  wisdom: false,
-  diplomacy: true,
-  rewards_earned: 987654321,
-  rewards_claimed: 123456789,
-  captured_summit: true,
-  used_revival_potion: false,
-  used_attack_potion: true,
-  max_attack_streak: true,
-};
-
-function assertLiveBeastStatsParityVector(): void {
-  const decoded = unpackLiveBeastStats(CROSS_LAYER_PARITY_PACKED);
-  for (const [key, value] of Object.entries(CROSS_LAYER_PARITY_EXPECTED)) {
-    if (decoded[key as keyof LiveBeastStats] !== value) {
-      throw new Error(`LiveBeastStats parity mismatch at ${key}`);
-    }
-  }
-}
-
-const importMetaWithEnv = import.meta as ImportMeta & { env?: { DEV?: boolean } };
-if (importMetaWithEnv.env?.DEV === true) {
-  assertLiveBeastStatsParityVector();
-}
-
 // ============ Event Decoders ============
 
 function hexToNumber(hex: string): number {


### PR DESCRIPTION
## Summary
- Removes the inline `assertLiveBeastStatsParityVector()` that ran on every module import during `vite dev`
- The assertion crashed the dev server with no recovery if it failed, and used a brittle `import.meta` type cast
- The same parity check is already covered more thoroughly by CI via `pnpm test:parity` (`scripts/test-live-beast-stats-parity.ts`), which tests zero, max, and flag isolation vectors in addition to the cross-layer parity vector

## Test plan
- [x] `pnpm build` passes
- [x] `pnpm test:parity` passes (standalone parity test still works)
- [ ] `pnpm dev` starts without runtime assertions on module load

🤖 Generated with [Claude Code](https://claude.com/claude-code)