### PR TITLE
feat(ci): make agent reviews required status checks

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -196,15 +196,28 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          sleep 5  # allow comment to propagate
+          MAX_ATTEMPTS=6
+          SLEEP_SECONDS=10
+          BODY=""
 
-          # Fetch the review comment posted by the action
-          BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
-            --paginate --jq '[.[] | select(.user.type == "Bot")] | last | .body // ""')
+          for i in $(seq 1 "$MAX_ATTEMPTS"); do
+            BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" \
+              --paginate --jq '[.[] | select(.user.login | test("claude"))] | last | .body // ""')
+
+            if [ -n "$BODY" ]; then
+              echo "Found Claude review comment on attempt $i"
+              break
+            fi
+
+            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
+              echo "Claude review comment not found yet; sleeping ${SLEEP_SECONDS}s... (attempt $i/$MAX_ATTEMPTS)"
+              sleep "$SLEEP_SECONDS"
+            fi
+          done
 
           if [ -z "$BODY" ]; then
-            echo "::warning::Could not find review comment — treating as pass"
-            exit 0
+            echo "::error::Could not find Claude review comment after $MAX_ATTEMPTS attempts"
+            exit 1
           fi
 
           # [CRITICAL] and [HIGH] with brackets only appear in actual findings,

--- a/.github/workflows/codex-review.yml
+++ b/.github/workflows/codex-review.yml
@@ -194,6 +194,7 @@ jobs:
             -o /tmp/review.txt \
             "$(cat /tmp/prompt.txt)" 2>&1 || {
               echo "Review process failed to complete." > /tmp/review.txt
+              exit 1
             }
           if [ -f /tmp/review.txt ]; then
             cat /tmp/review.txt
@@ -221,8 +222,8 @@ jobs:
         if: always()
         run: |
           if [ ! -s /tmp/review.txt ]; then
-            echo "::warning::No review output — treating as pass"
-            exit 0
+            echo "::error::No review output was produced despite reviewable changes"
+            exit 1
           fi
           if grep -qE '\[(CRITICAL|HIGH)\]' /tmp/review.txt; then
             echo "::error::Review found CRITICAL or HIGH severity issues"


### PR DESCRIPTION
## Summary
- Add verdict steps to both Claude and Codex review workflows that fail on `[CRITICAL]` or `[HIGH]` findings
- Add `summary` jobs with stable check names (`Claude Code Review / summary`, `Codex Review / summary`) suitable for branch protection rules
- Always post review comments (even when clean) for audit trail
- Improve Codex error handling by replacing `|| true` with a fallback message
- Update review prompts to always produce output including a severity summary line

## Manual follow-up
After these workflows run once on a PR, add the following to required status checks in branch protection for `main`:
- `Claude Code Review / summary`
- `Codex Review / summary`

## Test plan
- [ ] Docs-only PR — both summaries pass immediately (no reviews needed)
- [ ] Clean contract change — reviews run, post "no issues found", summaries pass
- [ ] PR with known issue — agent flags CRITICAL/HIGH, summary fails, merge blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)