### PR TITLE
fix(contracts): align fork test deploy calldata with summit constructor

### DIFF
--- a/contracts/tests/test_summit.cairo
+++ b/contracts/tests/test_summit.cairo
@@ -60,6 +60,7 @@ fn deploy_summit() -> ISummitSystemDispatcher {
     let start_timestamp = 1000_u64;
     let summit_duration_seconds = 1000000_u64;
     let summit_reward_amount_per_second = 0_u128;
+    let diplomacy_reward_amount_per_second = 0_u128;
     let quest_rewards_total_amount = 100_u128;
 
     let mut calldata = array![];
@@ -67,6 +68,7 @@ fn deploy_summit() -> ISummitSystemDispatcher {
     calldata.append(start_timestamp.into());
     calldata.append(summit_duration_seconds.into());
     calldata.append(summit_reward_amount_per_second.into());
+    calldata.append(diplomacy_reward_amount_per_second.into());
     calldata.append(quest_rewards_total_amount.into());
     calldata.append(DUNGEON_ADDRESS().into());
     calldata.append(BEAST_ADDRESS().into());
@@ -411,6 +413,7 @@ fn test_set_start_timestamp() {
     let start_timestamp = 9999999999_u64; // Future timestamp
     let summit_duration_seconds = 1000000_u64;
     let summit_reward_amount_per_second = 0_u128;
+    let diplomacy_reward_amount_per_second = 0_u128;
     let quest_rewards_total_amount = 100_u128;
 
     let mut calldata = array![];
@@ -418,6 +421,7 @@ fn test_set_start_timestamp() {
     calldata.append(start_timestamp.into());
     calldata.append(summit_duration_seconds.into());
     calldata.append(summit_reward_amount_per_second.into());
+    calldata.append(diplomacy_reward_amount_per_second.into());
     calldata.append(quest_rewards_total_amount.into());
     calldata.append(DUNGEON_ADDRESS().into());
     calldata.append(BEAST_ADDRESS().into());
@@ -1326,6 +1330,7 @@ fn test_set_start_timestamp_non_owner() {
     let start_timestamp = 9999999999_u64;
     let summit_duration_seconds = 1000000_u64;
     let summit_reward_amount_per_second = 0_u128;
+    let diplomacy_reward_amount_per_second = 0_u128;
     let quest_rewards_total_amount = 100_u128;
 
     let mut calldata = array![];
@@ -1333,6 +1338,7 @@ fn test_set_start_timestamp_non_owner() {
     calldata.append(start_timestamp.into());
     calldata.append(summit_duration_seconds.into());
     calldata.append(summit_reward_amount_per_second.into());
+    calldata.append(diplomacy_reward_amount_per_second.into());
     calldata.append(quest_rewards_total_amount.into());
     calldata.append(DUNGEON_ADDRESS().into());
     calldata.append(BEAST_ADDRESS().into());


### PR DESCRIPTION
## Summary
Fixes failing fork-based contract tests introduced after the summit constructor gained .

 had multiple deploy helpers still passing the old constructor calldata shape, causing deploy  failures and cascading test failures.

## Changes
- Added  to constructor calldata in all affected test deploy paths:
  - 
  -  setup deploy
  -  setup deploy

## Validation
-      Running test summit (snforge test)
    Updating git repository https://github.com/foundry-rs/starknet-foundry
    Updating git repository https://github.com/foundry-rs/starknet-foundry
   Compiling snforge_scarb_plugin v0.56.0
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Finished `release` profile [optimized] target(s) in 0.05s
   Compiling test(summit_unittest) summit v0.1.0 (/workspace/summit-next-fork-tests/contracts/Scarb.toml)
   Compiling test(summit_tests) summit_tests v0.1.0 (/workspace/summit-next-fork-tests/contracts/Scarb.toml)
    Finished `dev` profile target(s) in 1 second


Collected 1 test(s) from summit package
Running 0 test(s) from src/
Running 1 test(s) from tests/
[PASS] summit_tests::test_summit::test_add_extra_life_basic (l1_gas: ~0, l1_data_gas: ~2208, l2_gas: ~9654715)
Tests: 1 passed, 0 failed, 0 ignored, 250 filtered out

Latest block number = 6739759 for url = https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_10
-      Running test summit (snforge test)
    Updating git repository https://github.com/foundry-rs/starknet-foundry
    Updating git repository https://github.com/foundry-rs/starknet-foundry
   Compiling snforge_scarb_plugin v0.56.0
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Finished `release` profile [optimized] target(s) in 0.05s
   Compiling test(summit_unittest) summit v0.1.0 (/workspace/summit-next-fork-tests/contracts/Scarb.toml)
   Compiling test(summit_tests) summit_tests v0.1.0 (/workspace/summit-next-fork-tests/contracts/Scarb.toml)
    Finished `dev` profile target(s) in 1 second


Collected 3 test(s) from summit package
Running 0 test(s) from src/
Running 3 test(s) from tests/
[PASS] summit_tests::test_summit::test_set_start_timestamp (l1_gas: ~0, l1_data_gas: ~1536, l2_gas: ~1898130)
[PASS] summit_tests::test_summit::test_set_start_timestamp_non_owner (l1_gas: ~0, l1_data_gas: ~1536, l2_gas: ~1806360)
[PASS] summit_tests::test_summit::test_set_start_timestamp_after_summit_started (l1_gas: ~0, l1_data_gas: ~1920, l2_gas: ~2541100)
Tests: 3 passed, 0 failed, 0 ignored, 248 filtered out

Latest block number = 6739762 for url = https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_10
-      Running test summit (snforge test)
    Updating git repository https://github.com/foundry-rs/starknet-foundry
    Updating git repository https://github.com/foundry-rs/starknet-foundry
   Compiling snforge_scarb_plugin v0.56.0
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Blocking waiting for file lock on package cache
    Finished `release` profile [optimized] target(s) in 0.05s
   Compiling test(summit_unittest) summit v0.1.0 (/workspace/summit-next-fork-tests/contracts/Scarb.toml)
   Compiling test(summit_tests) summit_tests v0.1.0 (/workspace/summit-next-fork-tests/contracts/Scarb.toml)
    Finished `dev` profile target(s) in 1 second


Collected 1 test(s) from summit package
Running 1 test(s) from tests/
[PASS] summit_tests::test_summit::test_attack_basic (l1_gas: ~0, l1_data_gas: ~2208, l2_gas: ~7514123)
Running 0 test(s) from src/
Tests: 1 passed, 0 failed, 0 ignored, 250 filtered out

Latest block number = 6739764 for url = https://api.cartridge.gg/x/starknet/mainnet/rpc/v0_10

All passed locally.