### PR TITLE
fix(ci): make missing Claude review comment non-blocking

### DIFF
--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -216,8 +216,9 @@ jobs:
           done
 
           if [ -z "$BODY" ]; then
-            echo "::error::Could not find Claude review comment after $MAX_ATTEMPTS attempts"
-            exit 1
+            echo "::warning::Could not find Claude review comment after $MAX_ATTEMPTS attempts; treating as non-blocking"
+            echo "No blocking findings detected (review output unavailable)"
+            exit 0
           fi
 
           # [CRITICAL] and [HIGH] with brackets only appear in actual findings,


### PR DESCRIPTION
## Summary
Make `Claude Code Review` fail-open when the Claude comment is unavailable.

This addresses the validation-skip case seen on `next` PRs where the Anthropic action is skipped (workflow mismatch vs default branch), causing no comment to be posted and the gate step to fail.

## Changes
- Updated `.github/workflows/claude-review.yml` `Check for blocking findings`:
  - If no Claude comment is found after retries, emit a warning and pass.
  - Keep blocking behavior for real findings: still fails when `[CRITICAL]` or `[HIGH]` appears.

## Why
This preserves useful blocking on high-severity findings while avoiding false-negative red checks when review output is unavailable.
