### PR TITLE
fix(ci): prevent AI review comments from overwriting each other

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -388,7 +388,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: ${{ steps.build-prompt.outputs.prompt }}
-          use_sticky_comment: true
           allowed_tools: "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
       - name: Check for blocking findings
@@ -514,9 +513,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          COMMENT_MARKER="<!-- codex-review:contracts -->"
           {
-            echo "${COMMENT_MARKER}"
             echo "## Codex Review - Cairo/Starknet Contract Review"
             echo ""
             if [ -s /tmp/review.txt ]; then
@@ -526,21 +523,7 @@ jobs:
             fi
           } > /tmp/review-formatted.txt
 
-          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-            | jq -r --arg marker "$COMMENT_MARKER" '
-                .[] |
-                select(.user.login == "github-actions[bot]") |
-                select((.body // "") | contains($marker)) |
-                .id
-              ' \
-            | tail -n 1)
-
-          if [ -n "$EXISTING_COMMENT_ID" ]; then
-            jq -n --rawfile body /tmp/review-formatted.txt '{body: $body}' \
-              | gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" --method PATCH --input -
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
-          fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
       - name: Check for blocking findings
         if: always()
@@ -624,7 +607,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: ${{ steps.build-prompt.outputs.prompt }}
-          use_sticky_comment: true
           allowed_tools: "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
       - name: Check for blocking findings
@@ -750,9 +732,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          COMMENT_MARKER="<!-- codex-review:client -->"
           {
-            echo "${COMMENT_MARKER}"
             echo "## Codex Review - React/Frontend Review"
             echo ""
             if [ -s /tmp/review.txt ]; then
@@ -762,21 +742,7 @@ jobs:
             fi
           } > /tmp/review-formatted.txt
 
-          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-            | jq -r --arg marker "$COMMENT_MARKER" '
-                .[] |
-                select(.user.login == "github-actions[bot]") |
-                select((.body // "") | contains($marker)) |
-                .id
-              ' \
-            | tail -n 1)
-
-          if [ -n "$EXISTING_COMMENT_ID" ]; then
-            jq -n --rawfile body /tmp/review-formatted.txt '{body: $body}' \
-              | gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" --method PATCH --input -
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
-          fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
       - name: Check for blocking findings
         if: always()
@@ -860,7 +826,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: ${{ steps.build-prompt.outputs.prompt }}
-          use_sticky_comment: true
           allowed_tools: "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
       - name: Check for blocking findings
@@ -986,9 +951,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          COMMENT_MARKER="<!-- codex-review:indexer-api -->"
           {
-            echo "${COMMENT_MARKER}"
             echo "## Codex Review - Indexer/API Review"
             echo ""
             if [ -s /tmp/review.txt ]; then
@@ -998,21 +961,7 @@ jobs:
             fi
           } > /tmp/review-formatted.txt
 
-          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-            | jq -r --arg marker "$COMMENT_MARKER" '
-                .[] |
-                select(.user.login == "github-actions[bot]") |
-                select((.body // "") | contains($marker)) |
-                .id
-              ' \
-            | tail -n 1)
-
-          if [ -n "$EXISTING_COMMENT_ID" ]; then
-            jq -n --rawfile body /tmp/review-formatted.txt '{body: $body}' \
-              | gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" --method PATCH --input -
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
-          fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
       - name: Check for blocking findings
         if: always()
@@ -1097,7 +1046,6 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
           direct_prompt: ${{ steps.build-prompt.outputs.prompt }}
-          use_sticky_comment: true
           allowed_tools: "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
       - name: Check for blocking findings
@@ -1224,9 +1172,7 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          COMMENT_MARKER="<!-- codex-review:general -->"
           {
-            echo "${COMMENT_MARKER}"
             echo "## Codex Review - General Engineering Review"
             echo ""
             if [ -s /tmp/review.txt ]; then
@@ -1236,21 +1182,7 @@ jobs:
             fi
           } > /tmp/review-formatted.txt
 
-          EXISTING_COMMENT_ID=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-            | jq -r --arg marker "$COMMENT_MARKER" '
-                .[] |
-                select(.user.login == "github-actions[bot]") |
-                select((.body // "") | contains($marker)) |
-                .id
-              ' \
-            | tail -n 1)
-
-          if [ -n "$EXISTING_COMMENT_ID" ]; then
-            jq -n --rawfile body /tmp/review-formatted.txt '{body: $body}' \
-              | gh api "repos/${{ github.repository }}/issues/comments/${EXISTING_COMMENT_ID}" --method PATCH --input -
-          else
-            gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
-          fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
       - name: Check for blocking findings
         if: always()


### PR DESCRIPTION
## Summary
- Removed `use_sticky_comment: true` from all 4 Claude review jobs (`contracts`, `client`, `indexer-api`, `general`) so each run creates a new comment instead of overwriting the single sticky comment
- Simplified all 4 Codex review "Post review comment" steps to always `gh pr comment` instead of finding and PATCHing existing comments via HTML markers
- Net result: each of the 8 AI review jobs now creates a fresh comment, preventing concurrent jobs from clobbering each other's output

## Problem
The `claude-code-action` sticky comment mechanism has no per-job differentiator — it finds the most recent comment from the Claude bot and overwrites it. When multiple Claude review jobs run concurrently, the last one to finish wins and the other reviews are lost. The Codex jobs had an equivalent issue using HTML marker-based find-and-update logic.

## What stays unchanged
- All "Build review prompt" steps
- All "Run Claude/Codex review" steps (other than removing `use_sticky_comment`)
- All "Check for blocking findings" steps (Claude's API-polling check filters by heading with `| last`; Codex checks `/tmp/review.txt` directly)
- All job dependencies and conditions

## Test plan
- [ ] Verify YAML is valid (`python3 -c "import yaml; yaml.safe_load(open(...))"`)
- [ ] `grep -n 'use_sticky_comment' .github/workflows/pr-ci.yml` returns no results
- [ ] `grep -n 'COMMENT_MARKER\|EXISTING_COMMENT_ID' .github/workflows/pr-ci.yml` returns no results
- [ ] `grep -n 'PATCH --input' .github/workflows/pr-ci.yml` returns no results
- [ ] Confirm all 4 Codex "Post review comment" steps use simple `gh pr comment` only
- [ ] Open a test PR touching multiple scopes and verify all review comments appear independently

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Simplified pull request review comment handling by streamlining the feedback posting process. Review comments are now posted consistently across all review steps without the complexity of managing comment updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->