### PR TITLE
ci: sync workflow from next — add API test coverage

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -321,6 +321,16 @@ jobs:
       - name: Build
         run: pnpm build
 
+      - name: Run tests with coverage
+        run: pnpm test:coverage
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v4
+        with:
+          file: ./api/coverage/lcov.info
+          flags: api
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   claude-review-contracts:
     needs: [changes, contracts-lint]
     if: needs.changes.outputs.contracts == 'true'


### PR DESCRIPTION
## Summary
- Syncs `.github/workflows/pr-ci.yml` from `next` to `main`
- Adds `pnpm test:coverage` step to the API job
- Adds Codecov upload for API coverage (`flags: api`)

## Context
The `next` branch had API test coverage steps that were missing from `main`. This PR brings `main` in sync so that the API pipeline matches across both branches.

## Verification
- The diff matches exactly: `git diff main next -- .github/workflows/pr-ci.yml`
- Only one file modified: `.github/workflows/pr-ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced continuous integration workflow to include automated test coverage reporting and tracking for both main development and API testing pipelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->