### PR TITLE
[codex] fix client lint errors

### DIFF
--- a/client/src/components/ActionBar.test.tsx
+++ b/client/src/components/ActionBar.test.tsx
@@ -1,4 +1,5 @@
 import { act, create } from "react-test-renderer";
+import type { ReactTestRenderer } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const executeGameActionMock = vi.fn();
@@ -147,9 +148,13 @@ describe("ActionBar token balance coercion", () => {
   });
 
   it("renders with missing balance keys without crashing", async () => {
+    let renderer: ReactTestRenderer | undefined;
+
     await act(async () => {
-      create(<ActionBar />);
+      renderer = create(<ActionBar />);
     });
+
+    expect(renderer?.toJSON()).not.toBeNull();
   });
 
   it("renders with populated balances without crashing", async () => {
@@ -160,9 +165,13 @@ describe("ActionBar token balance coercion", () => {
       POISON: 13,
     };
 
+    let renderer: ReactTestRenderer | undefined;
+
     await act(async () => {
-      create(<ActionBar />);
+      renderer = create(<ActionBar />);
     });
+
+    expect(renderer?.toJSON()).not.toBeNull();
   });
 
   it("handles invalid balance values without crashing", async () => {
@@ -173,8 +182,12 @@ describe("ActionBar token balance coercion", () => {
       POISON: undefined as unknown as number,
     };
 
+    let renderer: ReactTestRenderer | undefined;
+
     await act(async () => {
-      create(<ActionBar />);
+      renderer = create(<ActionBar />);
     });
+
+    expect(renderer?.toJSON()).not.toBeNull();
   });
 });

--- a/client/src/components/ActionBar.tsx
+++ b/client/src/components/ActionBar.tsx
@@ -46,7 +46,7 @@ function ActionBar() {
   const { selectedBeasts, summit,
     attackInProgress,
     applyingPotions, appliedPoisonCount, setAppliedPoisonCount,
-    collection, collectionSyncing, setSelectedBeasts, attackMode, setAttackMode,
+    collection, collectionSyncing, attackMode, setAttackMode,
     autopilotEnabled, appliedExtraLifePotions, setAppliedExtraLifePotions } = useGameStore();
   const {
     extraLifeStrategy,
@@ -64,7 +64,6 @@ function ActionBar() {
   } = useAutopilotStore();
 
   const {
-    collectionWithCombat,
     isSavage,
     enableAttack,
     revivalPotionsRequired,

--- a/client/src/components/BeastCollection.tsx
+++ b/client/src/components/BeastCollection.tsx
@@ -1,7 +1,7 @@
 import { useController } from '@/contexts/controller';
 import { MAX_BEASTS_PER_ATTACK } from '@/contexts/GameDirector';
 import { useQuestGuide } from '@/contexts/QuestGuide';
-import type { BeastTypeFilter, QuestFilterKey, SortMethod } from '@/stores/gameStore';
+import type { QuestFilterKey, SortMethod } from '@/stores/gameStore';
 import { useGameStore } from '@/stores/gameStore';
 import type { Beast, selection } from '@/types/game';
 import {
@@ -44,7 +44,7 @@ function BeastCollection() {
     attackInProgress, summit, attackMode,
     hideDeadBeasts, setHideDeadBeasts,
     sortMethod, setSortMethod,
-    typeFilter, setTypeFilter,
+    typeFilter,
     nameMatchFilter, setNameMatchFilter,
     questFilter, toggleQuestFilter,
   } = useGameStore()
@@ -72,12 +72,12 @@ function BeastCollection() {
         selection[0].token_id === beastId ? [selection[0], next, selection[2]] : selection
       )
     );
-  }, []);
+  }, [setSelectedBeasts]);
 
   const setBulkAttacks = useCallback((count: number) => {
     const next = clampAttacks(count);
     setSelectedBeasts((prev) => prev.map((s) => [s[0], next, s[2]]));
-  }, []);
+  }, [setSelectedBeasts]);
 
   const setBulkPotions = useCallback((mode: 'none' | 'optimal' | 'max' | number) => {
     const maxAvailable = Math.min(tokenBalances["ATTACK"] || 0, 255);
@@ -99,7 +99,7 @@ function BeastCollection() {
       const value = Math.max(0, Math.min(maxAvailable, mode));
       setSelectedBeasts((prev) => prev.map((s) => [s[0], s[1], value]));
     }
-  }, [summit, tokenBalances]);
+  }, [setSelectedBeasts, summit, tokenBalances]);
 
   const isStrongAgainst = (attackerType: string, defenderType: string): boolean => {
     return (
@@ -225,7 +225,7 @@ function BeastCollection() {
     }
 
     return collection.sort((a, b) => b.power - a.power)
-  }, [collection, summit?.beast.token_id, sortMethod, typeFilter, nameMatchFilter, hideDeadBeasts, questFilter]);
+  }, [collection, summit, sortMethod, typeFilter, nameMatchFilter, hideDeadBeasts, questFilter]);
 
   const selectBeast = useCallback((beast: Beast, isFirstBeast: boolean = false) => {
     if (attackInProgress || attackMode === 'autopilot') return;
@@ -241,8 +241,7 @@ function BeastCollection() {
     } else {
       setSelectedBeasts((prev: selection) => [...prev, [beast, 1, 0]]);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [attackInProgress, attackMode, selectedBeasts, notifyTargetClicked]);
+  }, [attackInProgress, attackMode, selectedBeasts, setSelectedBeasts, notifyTargetClicked]);
 
   const selectAllBeasts = () => {
     if (attackInProgress) return;

--- a/client/src/components/Leaderboard.test.tsx
+++ b/client/src/components/Leaderboard.test.tsx
@@ -17,6 +17,12 @@ vi.mock("@/contexts/Statistics", () => ({
   useStatistics: () => ({
     beastsRegistered: 10,
     beastsAlive: 3,
+    consumablesSupply: {
+      attack: 100,
+      revive: 200,
+      xlife: 300,
+      poison: 400,
+    },
     fetchBeastCounts: hoisted.fetchBeastCountsMock,
   }),
 }));

--- a/client/src/components/dialogs/AutopilotConfigModal.tsx
+++ b/client/src/components/dialogs/AutopilotConfigModal.tsx
@@ -129,7 +129,6 @@ function TargetedPoisonSection({ players, onAdd, onRemove, onAmountChange, poiso
       finally { setLoading(false); }
     }, 400);
     return () => { if (debounceRef.current) clearTimeout(debounceRef.current); };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [input]);
 
   const handleAdd = () => {
@@ -428,7 +427,6 @@ function AutopilotConfigModal(props: AutopilotConfigModalProps) {
     return () => {
       if (debounceRef.current) clearTimeout(debounceRef.current);
     };
-  // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ignoredInput]);
 
   const handleResetToDefaults = () => {

--- a/client/src/components/dialogs/DCATab.tsx
+++ b/client/src/components/dialogs/DCATab.tsx
@@ -9,7 +9,6 @@ import {
   computeTwammTimes,
   generateCreateDcaOrderCalls,
   generateWithdrawProceedsCalls,
-  generateCancelDcaOrderCalls,
   fetchTwammOrders,
   getDcaOrderProceeds,
 } from '@/api/ekubo';
@@ -17,7 +16,6 @@ import { TOKEN_ADDRESS } from '@/utils/networkConfig';
 import type { NetworkConfig } from '@/utils/networkConfig';
 import { gameColors } from '@/utils/themes';
 import { formatAmount } from '@/utils/utils';
-import CancelIcon from '@mui/icons-material/Close';
 import DownloadIcon from '@mui/icons-material/Download';
 import RefreshIcon from '@mui/icons-material/Refresh';
 import {
@@ -120,7 +118,7 @@ export default function DCATab({
   const refreshOrders = useCallback(async () => {
     if (!address) return;
 
-    let apiPositions: TwammApiPosition[] = [];
+    let apiPositions: TwammApiPosition[];
     try {
       apiPositions = await fetchTwammOrders(address);
     } catch (err) {
@@ -316,8 +314,9 @@ export default function DCATab({
       // Remove order from the list
       setActiveOrders((prev) => prev.filter((o) => o.tokenId !== order.tokenId));
       setProceedsMap((prev) => {
-        const { [order.tokenId]: _, ...rest } = prev;
-        return rest;
+        const next = { ...prev };
+        delete next[order.tokenId];
+        return next;
       });
     } catch (err) {
       console.error('Failed to withdraw proceeds:', err);

--- a/client/src/components/dialogs/MarketplaceModal.tsx
+++ b/client/src/components/dialogs/MarketplaceModal.tsx
@@ -44,16 +44,6 @@ interface Potion {
   color: string;
 }
 
-interface UserToken {
-  symbol: string;
-  balance: string;
-  rawBalance: number;
-  address: string;
-  decimals: number;
-  displayDecimals: number;
-  price: number;
-}
-
 const POTIONS: Potion[] = [
   {
     id: 'ATTACK',

--- a/client/src/contexts/GameDirector.tsx
+++ b/client/src/contexts/GameDirector.tsx
@@ -23,8 +23,7 @@ import {
   getBeastDetails,
   getBeastRevivalTime,
 } from "@/utils/beasts";
-import { useAccount } from "@starknet-react/core";
-import { addAddressPadding, type Call } from "starknet";
+import type { Call } from "starknet";
 import type {
   PropsWithChildren
 } from "react";
@@ -71,7 +70,6 @@ const isSummitEvent = (
 ): event is SummitEventTranslation => event.componentName === "Summit";
 
 export const GameDirector = ({ children }: PropsWithChildren) => {
-  const { account } = useAccount();
   const { currentNetworkConfig } = useDynamicConnector();
   const {
     summit,
@@ -160,7 +158,6 @@ export const GameDirector = ({ children }: PropsWithChildren) => {
     addLiveEvent(data);
 
     const { category, sub_category, data: eventData } = data;
-    const isOwnEvent = data.player === addAddressPadding(account?.address ?? "");
 
     // Helper to get beast info from event data
     const getBeastInfo = () => {
@@ -741,7 +738,6 @@ export const GameDirector = ({ children }: PropsWithChildren) => {
       } : prev);
     } else if (action.type === "apply_poison") {
       const poisonCount = action.count ?? 0;
-      const beastId = action.beastId ?? 0;
       setTokenBalances((prev: Record<string, number>) => ({
         ...prev,
         POISON: (prev["POISON"] || 0) - poisonCount,

--- a/client/src/contexts/Statistics.test.tsx
+++ b/client/src/contexts/Statistics.test.tsx
@@ -1,9 +1,10 @@
 import { act, create } from "react-test-renderer";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-const { getSwapQuoteMock, getBeastCountsMock, getQuestRewardsTotalMock, mockNetworkConfig } = vi.hoisted(() => ({
+const { getSwapQuoteMock, getBeastCountsMock, getConsumablesSupplyMock, getQuestRewardsTotalMock, mockNetworkConfig } = vi.hoisted(() => ({
   getSwapQuoteMock: vi.fn(async () => ({ total: "-2000000", totalDisplay: -2e6 })),
   getBeastCountsMock: vi.fn(async () => ({ total: 12, alive: 5, dead: 7 })),
+  getConsumablesSupplyMock: vi.fn(async () => ({ attack: 1, revive: 2, xlife: 3, poison: 4 })),
   getQuestRewardsTotalMock: vi.fn(async () => 25),
   mockNetworkConfig: {
     tokens: {
@@ -22,6 +23,7 @@ vi.mock("@/api/ekubo", () => ({
 vi.mock("@/api/summitApi", () => ({
   useSummitApi: () => ({
     getBeastCounts: getBeastCountsMock,
+    getConsumablesSupply: getConsumablesSupplyMock,
     getQuestRewardsTotal: getQuestRewardsTotalMock,
   }),
 }));
@@ -68,6 +70,7 @@ describe("StatisticsProvider", () => {
     await flushEffects();
 
     expect(getBeastCountsMock).toHaveBeenCalledTimes(1);
+    expect(getConsumablesSupplyMock).toHaveBeenCalledTimes(1);
     expect(getQuestRewardsTotalMock).toHaveBeenCalledTimes(1);
     expect(getSwapQuoteMock).toHaveBeenCalledTimes(2);
     const firstCall = getSwapQuoteMock.mock.calls[0] as unknown as [bigint, string, string];

--- a/client/src/hooks/useAutopilotOrchestrator.ts
+++ b/client/src/hooks/useAutopilotOrchestrator.ts
@@ -232,7 +232,7 @@ export function useAutopilotOrchestrator() {
         beast.prefix === summit.beast.prefix &&
         beast.suffix === summit.beast.suffix,
     );
-  }, [skipSharedDiplomacy, summit?.beast?.token_id, collection.length]);
+  }, [skipSharedDiplomacy, summit?.beast, collection]);
 
   const summitOwnerIgnored = useMemo(() => {
     if (ignoredPlayers.length === 0 || !summit?.owner) return false;
@@ -383,7 +383,7 @@ export function useAutopilotOrchestrator() {
     if (autopilotEnabled && !attackInProgress && summit?.beast.extra_lives === 0 && summit?.beast.current_health === 1) {
       setTriggerAutopilot();
     }
-  }, [autopilotEnabled, summit?.beast.current_health]);
+  }, [autopilotEnabled, attackInProgress, summit?.beast.current_health, summit?.beast.extra_lives]);
 
   // ── Return values needed by ActionBar UI ─────────────────────────────
 


### PR DESCRIPTION
## Summary
- adds explicit assertions to the ActionBar token balance tests
- removes stale unused imports, destructured values, and dead types from client components
- updates hook dependency arrays instead of suppressing current lint warnings

## Impact
Client lint should pass again, allowing the client CI path and updated Codex PR review workflow to run on this PR.

## Validation
- `cd client && pnpm lint:ci`
- `cd client && pnpm exec vitest run src/components/ActionBar.test.tsx`
- `cd client && pnpm build`