### PR TITLE
test: trigger Claude reviews across api/client/contracts scopes

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -168,3 +168,5 @@ Realtime pipeline:
 API CI runs:
 
 `pnpm exec tsc --noEmit -> pnpm build`.
+
+For the broader CI matrix (which scopes trigger which jobs), see `../AGENTS.md`.

--- a/client/README.md
+++ b/client/README.md
@@ -114,3 +114,5 @@ Tailwind is not used in this project.
 Client CI runs on `client/**` and `contracts/src/models/beast.cairo` changes:
 
 `lint -> build -> test:parity -> test:coverage -> Codecov`.
+
+For the broader CI matrix (which scopes trigger which jobs), see `../AGENTS.md`.

--- a/contracts/README.md
+++ b/contracts/README.md
@@ -309,3 +309,5 @@ If you change packed layout or field order, update and re-verify:
 - `indexer/src/lib/decoder.ts`
 - `client/src/utils/translation.ts`
 - parity scripts in `indexer/scripts/` and `client/scripts/`
+
+For the broader CI matrix (which scopes trigger which jobs), see `../AGENTS.md`.


### PR DESCRIPTION
## Summary

Trivial cross-link addition (one identical line) to `api/README.md`, `client/README.md`, and `contracts/README.md`. The sole purpose is to exercise all three scoped Claude review jobs (and their Codex pairs) end-to-end after the v1 migration in #143:

- `client_review` (changes under `client/**`)
- `indexer_api_review` (changes under `api/**`)
- `contracts_review` (changes under `contracts/**`)

Expected behavior on this PR:
- All three `claude-review-*` jobs run on `claude-code-action@v1.0.111` with `--model claude-opus-4-7`
- Each job posts a `## Claude Review - …` comment with a `REVIEW_MARKER` line
- The `Check for blocking findings` step finds the comment and gates on `[CRITICAL]`/`[HIGH]`
- `pr-ci` final gate passes

If the reviews surface real `[HIGH]` findings on this trivial doc change, that's a prompt-tuning issue, not a workflow issue — close and tune the prompt files.

## Test plan

- [ ] All four AI review jobs (Claude + Codex × 3 scopes — contracts/client/indexer-api) run, post comments, and pass blocking-findings check
- [ ] `claude-review-general` is **not** triggered (no files outside the four scoped trees)
- [ ] `pr-ci` passes
- [ ] Close without merging once verified (the cross-link is harmless but unnecessary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated README guidance across API, client, and contracts sections to add cross-references to the broader CI matrix.
  * Clarified where to find how CI jobs are scoped and how triggers map to jobs, improving discoverability of CI configuration details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->