### PR TITLE
ci: post Claude reviews from execution_file; fix general_review filter

### DIFF
--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -66,10 +66,7 @@ jobs:
               - ".github/prompts/**"
               - ".github/actions/**"
 
-      # dorny/paths-filter @v3 OR-list semantics don't reliably honor `!`
-      # negations against a leading `**` (changed files inside excluded
-      # scopes still match). Compute general_review explicitly: true iff
-      # the PR touches at least one file outside the four scoped trees.
+      # True iff the PR touches a file outside contracts/, client/, indexer/, api/.
       - name: Compute general_review
         id: general
         env:
@@ -505,9 +502,6 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
-          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
-          # way `direct_prompt:` did in beta. Capture Claude's final text from
-          # the streaming-JSON execution file and write it to /tmp/review.txt.
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
             echo "Claude action did not produce an execution file." > /tmp/review.txt
             exit 0
@@ -749,9 +743,6 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
-          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
-          # way `direct_prompt:` did in beta. Capture Claude's final text from
-          # the streaming-JSON execution file and write it to /tmp/review.txt.
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
             echo "Claude action did not produce an execution file." > /tmp/review.txt
             exit 0
@@ -993,9 +984,6 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
-          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
-          # way `direct_prompt:` did in beta. Capture Claude's final text from
-          # the streaming-JSON execution file and write it to /tmp/review.txt.
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
             echo "Claude action did not produce an execution file." > /tmp/review.txt
             exit 0
@@ -1238,9 +1226,6 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
-          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
-          # way `direct_prompt:` did in beta. Capture Claude's final text from
-          # the streaming-JSON execution file and write it to /tmp/review.txt.
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
             echo "Claude action did not produce an execution file." > /tmp/review.txt
             exit 0

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -502,9 +502,11 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
+          : > /tmp/review.txt
+
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
-            echo "Claude action did not produce an execution file." > /tmp/review.txt
-            exit 0
+            echo "::error::Claude action did not produce an execution file"
+            exit 1
           fi
 
           REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
@@ -512,7 +514,8 @@ jobs:
             REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
           fi
           if [ -z "$REVIEW" ]; then
-            REVIEW="Claude review did not produce output."
+            echo "::error::Claude review produced no extractable output"
+            exit 1
           fi
           printf '%s\n' "$REVIEW" > /tmp/review.txt
 
@@ -743,9 +746,11 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
+          : > /tmp/review.txt
+
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
-            echo "Claude action did not produce an execution file." > /tmp/review.txt
-            exit 0
+            echo "::error::Claude action did not produce an execution file"
+            exit 1
           fi
 
           REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
@@ -753,7 +758,8 @@ jobs:
             REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
           fi
           if [ -z "$REVIEW" ]; then
-            REVIEW="Claude review did not produce output."
+            echo "::error::Claude review produced no extractable output"
+            exit 1
           fi
           printf '%s\n' "$REVIEW" > /tmp/review.txt
 
@@ -984,9 +990,11 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
+          : > /tmp/review.txt
+
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
-            echo "Claude action did not produce an execution file." > /tmp/review.txt
-            exit 0
+            echo "::error::Claude action did not produce an execution file"
+            exit 1
           fi
 
           REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
@@ -994,7 +1002,8 @@ jobs:
             REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
           fi
           if [ -z "$REVIEW" ]; then
-            REVIEW="Claude review did not produce output."
+            echo "::error::Claude review produced no extractable output"
+            exit 1
           fi
           printf '%s\n' "$REVIEW" > /tmp/review.txt
 
@@ -1226,9 +1235,11 @@ jobs:
         env:
           EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
         run: |
+          : > /tmp/review.txt
+
           if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
-            echo "Claude action did not produce an execution file." > /tmp/review.txt
-            exit 0
+            echo "::error::Claude action did not produce an execution file"
+            exit 1
           fi
 
           REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
@@ -1236,7 +1247,8 @@ jobs:
             REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
           fi
           if [ -z "$REVIEW" ]; then
-            REVIEW="Claude review did not produce output."
+            echo "::error::Claude review produced no extractable output"
+            exit 1
           fi
           printf '%s\n' "$REVIEW" > /tmp/review.txt
 

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -23,7 +23,7 @@ jobs:
       api: ${{ steps.filter.outputs.api }}
       indexer_api_ci: ${{ steps.filter.outputs.indexer_api_ci }}
       indexer_api_review: ${{ steps.filter.outputs.indexer_api_review }}
-      general_review: ${{ steps.filter.outputs.general_review }}
+      general_review: ${{ steps.general.outputs.general_review }}
       can_run_ai_reviews: ${{ steps.ai-gate.outputs.can_run_ai_reviews }}
       ai_reviews_block_reason: ${{ steps.ai-gate.outputs.ai_reviews_block_reason }}
       can_run_claude_reviews: ${{ steps.ai-gate.outputs.can_run_claude_reviews }}
@@ -65,12 +65,24 @@ jobs:
               - ".github/workflows/pr-ci.yml"
               - ".github/prompts/**"
               - ".github/actions/**"
-            general_review:
-              - "**"
-              - "!contracts/**"
-              - "!client/**"
-              - "!indexer/**"
-              - "!api/**"
+
+      # dorny/paths-filter @v3 OR-list semantics don't reliably honor `!`
+      # negations against a leading `**` (changed files inside excluded
+      # scopes still match). Compute general_review explicitly: true iff
+      # the PR touches at least one file outside the four scoped trees.
+      - name: Compute general_review
+        id: general
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          NON_SCOPED=$(gh pr diff "$PR_NUMBER" --name-only \
+            | grep -Ev '^(contracts|client|indexer|api)/' || true)
+          if [ -n "$NON_SCOPED" ]; then
+            echo "general_review=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "general_review=false" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Determine AI review availability
         id: ai-gate
@@ -478,6 +490,7 @@ jobs:
           echo "${DELIMITER}" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude review
+        id: claude
         # v1.0.111 — pin by SHA for security (third-party action with write perms + secrets).
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
         with:
@@ -487,45 +500,54 @@ jobs:
             --model claude-opus-4-7
             --allowedTools "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
-      - name: Check for blocking findings
+      - name: Extract review output
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
+          # way `direct_prompt:` did in beta. Capture Claude's final text from
+          # the streaming-JSON execution file and write it to /tmp/review.txt.
+          if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "Claude action did not produce an execution file." > /tmp/review.txt
+            exit 0
+          fi
+
+          REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
+          if [ -z "$REVIEW" ]; then
+            REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
+          fi
+          if [ -z "$REVIEW" ]; then
+            REVIEW="Claude review did not produce output."
+          fi
+          printf '%s\n' "$REVIEW" > /tmp/review.txt
+
+      - name: Post review comment
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          HEADER: "## Claude Review - Cairo/Starknet Contract Review"
-          REVIEW_MARKER: run=${{ github.run_id }} attempt=${{ github.run_attempt }} sha=${{ github.event.pull_request.head.sha }} scope=contracts
         run: |
-          MAX_ATTEMPTS=6
-          SLEEP_SECONDS=10
-          BODY=""
-
-          for i in $(seq 1 "$MAX_ATTEMPTS"); do
-            BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-              | jq -r --arg header "$HEADER" --arg marker "$REVIEW_MARKER" \
-                '[.[] | select((.body // "") | contains($header) and contains($marker))] | last | .body // ""')
-
-            if [ -z "$BODY" ]; then
-              BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-                | jq -r --arg header "$HEADER" --arg run_token "run=${{ github.run_id }}" --arg sha_token "sha=${{ github.event.pull_request.head.sha }}" \
-                  '[.[] | select((.body // "") | contains($header) and contains($run_token) and contains($sha_token))] | last | .body // ""')
+          {
+            echo "## Claude Review - Cairo/Starknet Contract Review"
+            echo ""
+            if [ -s /tmp/review.txt ]; then
+              cat /tmp/review.txt
+            else
+              echo "No review output was produced."
             fi
+          } > /tmp/review-formatted.txt
 
-            if [ -n "$BODY" ]; then
-              echo "Found Claude review comment on attempt $i"
-              break
-            fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
-            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
-              echo "Claude review comment not found yet; sleeping ${SLEEP_SECONDS}s... (attempt $i/$MAX_ATTEMPTS)"
-              sleep "$SLEEP_SECONDS"
-            fi
-          done
-
-          if [ -z "$BODY" ]; then
-            echo "::error::Could not find Claude review output for contracts"
+      - name: Check for blocking findings
+        if: always()
+        run: |
+          if [ ! -s /tmp/review.txt ]; then
+            echo "::error::No review output was produced despite reviewable changes"
             exit 1
           fi
 
-          if echo "$BODY" | grep -qE '\[(CRITICAL|HIGH)\]'; then
+          if grep -qE '\[(CRITICAL|HIGH)\]' /tmp/review.txt; then
             echo "::error::Review found CRITICAL or HIGH severity issues"
             exit 1
           fi
@@ -712,6 +734,7 @@ jobs:
           echo "${DELIMITER}" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude review
+        id: claude
         # v1.0.111 — pin by SHA for security (third-party action with write perms + secrets).
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
         with:
@@ -721,45 +744,54 @@ jobs:
             --model claude-opus-4-7
             --allowedTools "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
-      - name: Check for blocking findings
+      - name: Extract review output
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
+          # way `direct_prompt:` did in beta. Capture Claude's final text from
+          # the streaming-JSON execution file and write it to /tmp/review.txt.
+          if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "Claude action did not produce an execution file." > /tmp/review.txt
+            exit 0
+          fi
+
+          REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
+          if [ -z "$REVIEW" ]; then
+            REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
+          fi
+          if [ -z "$REVIEW" ]; then
+            REVIEW="Claude review did not produce output."
+          fi
+          printf '%s\n' "$REVIEW" > /tmp/review.txt
+
+      - name: Post review comment
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          HEADER: "## Claude Review - React/Frontend Review"
-          REVIEW_MARKER: run=${{ github.run_id }} attempt=${{ github.run_attempt }} sha=${{ github.event.pull_request.head.sha }} scope=client
         run: |
-          MAX_ATTEMPTS=6
-          SLEEP_SECONDS=10
-          BODY=""
-
-          for i in $(seq 1 "$MAX_ATTEMPTS"); do
-            BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-              | jq -r --arg header "$HEADER" --arg marker "$REVIEW_MARKER" \
-                '[.[] | select((.body // "") | contains($header) and contains($marker))] | last | .body // ""')
-
-            if [ -z "$BODY" ]; then
-              BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-                | jq -r --arg header "$HEADER" --arg run_token "run=${{ github.run_id }}" --arg sha_token "sha=${{ github.event.pull_request.head.sha }}" \
-                  '[.[] | select((.body // "") | contains($header) and contains($run_token) and contains($sha_token))] | last | .body // ""')
+          {
+            echo "## Claude Review - React/Frontend Review"
+            echo ""
+            if [ -s /tmp/review.txt ]; then
+              cat /tmp/review.txt
+            else
+              echo "No review output was produced."
             fi
+          } > /tmp/review-formatted.txt
 
-            if [ -n "$BODY" ]; then
-              echo "Found Claude review comment on attempt $i"
-              break
-            fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
-            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
-              echo "Claude review comment not found yet; sleeping ${SLEEP_SECONDS}s... (attempt $i/$MAX_ATTEMPTS)"
-              sleep "$SLEEP_SECONDS"
-            fi
-          done
-
-          if [ -z "$BODY" ]; then
-            echo "::error::Could not find Claude review output for client"
+      - name: Check for blocking findings
+        if: always()
+        run: |
+          if [ ! -s /tmp/review.txt ]; then
+            echo "::error::No review output was produced despite reviewable changes"
             exit 1
           fi
 
-          if echo "$BODY" | grep -qE '\[(CRITICAL|HIGH)\]'; then
+          if grep -qE '\[(CRITICAL|HIGH)\]' /tmp/review.txt; then
             echo "::error::Review found CRITICAL or HIGH severity issues"
             exit 1
           fi
@@ -946,6 +978,7 @@ jobs:
           echo "${DELIMITER}" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude review
+        id: claude
         # v1.0.111 — pin by SHA for security (third-party action with write perms + secrets).
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
         with:
@@ -955,57 +988,54 @@ jobs:
             --model claude-opus-4-7
             --allowedTools "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
-      - name: Check for blocking findings
+      - name: Extract review output
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
+          # way `direct_prompt:` did in beta. Capture Claude's final text from
+          # the streaming-JSON execution file and write it to /tmp/review.txt.
+          if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "Claude action did not produce an execution file." > /tmp/review.txt
+            exit 0
+          fi
+
+          REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
+          if [ -z "$REVIEW" ]; then
+            REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
+          fi
+          if [ -z "$REVIEW" ]; then
+            REVIEW="Claude review did not produce output."
+          fi
+          printf '%s\n' "$REVIEW" > /tmp/review.txt
+
+      - name: Post review comment
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          HEADER: "## Claude Review - Indexer/API Review"
-          REVIEW_MARKER: run=${{ github.run_id }} attempt=${{ github.run_attempt }} sha=${{ github.event.pull_request.head.sha }} scope=indexer-api
         run: |
-          MAX_ATTEMPTS=6
-          SLEEP_SECONDS=10
-          BODY=""
-
-          for i in $(seq 1 "$MAX_ATTEMPTS"); do
-            BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-              | jq -r --arg header "$HEADER" --arg marker "$REVIEW_MARKER" \
-                '[.[] | select((.body // "") | contains($header) and contains($marker))] | last | .body // ""')
-
-            if [ -z "$BODY" ]; then
-              BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-                | jq -r --arg header "$HEADER" --arg run_token "run=${{ github.run_id }}" --arg sha_token "sha=${{ github.event.pull_request.head.sha }}" \
-                  '[.[] | select((.body // "") | contains($header) and contains($run_token) and contains($sha_token))] | last | .body // ""')
+          {
+            echo "## Claude Review - Indexer/API Review"
+            echo ""
+            if [ -s /tmp/review.txt ]; then
+              cat /tmp/review.txt
+            else
+              echo "No review output was produced."
             fi
+          } > /tmp/review-formatted.txt
 
-            if [ -z "$BODY" ]; then
-              BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-                | jq -r --arg marker "$REVIEW_MARKER" \
-                  '[.[] | select((.user.login // "") == "claude" and ((.body // "") | contains($marker)))] | last | .body // ""')
-            fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
-            if [ -z "$BODY" ]; then
-              BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-                | jq -r --arg run_token "run=${{ github.run_id }}" --arg sha_token "sha=${{ github.event.pull_request.head.sha }}" \
-                  '[.[] | select((.user.login // "") == "claude" and ((.body // "") | contains($run_token) and contains($sha_token) and contains("scope=indexer-api")))] | last | .body // ""')
-            fi
-
-            if [ -n "$BODY" ]; then
-              echo "Found Claude review comment on attempt $i"
-              break
-            fi
-
-            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
-              echo "Claude review comment not found yet; sleeping ${SLEEP_SECONDS}s... (attempt $i/$MAX_ATTEMPTS)"
-              sleep "$SLEEP_SECONDS"
-            fi
-          done
-
-          if [ -z "$BODY" ]; then
-            echo "::error::Could not find Claude review output for indexer/api"
+      - name: Check for blocking findings
+        if: always()
+        run: |
+          if [ ! -s /tmp/review.txt ]; then
+            echo "::error::No review output was produced despite reviewable changes"
             exit 1
           fi
 
-          if echo "$BODY" | grep -qE '\[(CRITICAL|HIGH)\]'; then
+          if grep -qE '\[(CRITICAL|HIGH)\]' /tmp/review.txt; then
             echo "::error::Review found CRITICAL or HIGH severity issues"
             exit 1
           fi
@@ -1193,6 +1223,7 @@ jobs:
           echo "${DELIMITER}" >> "$GITHUB_OUTPUT"
 
       - name: Run Claude review
+        id: claude
         # v1.0.111 — pin by SHA for security (third-party action with write perms + secrets).
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa
         with:
@@ -1202,45 +1233,54 @@ jobs:
             --model claude-opus-4-7
             --allowedTools "Bash(git diff *),Bash(git log *),Bash(git show *),Read,Glob,Grep"
 
-      - name: Check for blocking findings
+      - name: Extract review output
+        if: always()
+        env:
+          EXECUTION_FILE: ${{ steps.claude.outputs.execution_file }}
+        run: |
+          # v1 doesn't auto-post a PR comment in `prompt:` automation mode the
+          # way `direct_prompt:` did in beta. Capture Claude's final text from
+          # the streaming-JSON execution file and write it to /tmp/review.txt.
+          if [ -z "$EXECUTION_FILE" ] || [ ! -f "$EXECUTION_FILE" ]; then
+            echo "Claude action did not produce an execution file." > /tmp/review.txt
+            exit 0
+          fi
+
+          REVIEW=$(jq -r 'select(.type == "result") | .result // empty' "$EXECUTION_FILE" 2>/dev/null | tail -1)
+          if [ -z "$REVIEW" ]; then
+            REVIEW=$(jq -r 'select(.type == "assistant") | .message.content[]? | select(.type == "text") | .text // empty' "$EXECUTION_FILE" 2>/dev/null)
+          fi
+          if [ -z "$REVIEW" ]; then
+            REVIEW="Claude review did not produce output."
+          fi
+          printf '%s\n' "$REVIEW" > /tmp/review.txt
+
+      - name: Post review comment
         if: always()
         env:
           GH_TOKEN: ${{ github.token }}
-          HEADER: "## Claude Review - General Engineering Review"
-          REVIEW_MARKER: run=${{ github.run_id }} attempt=${{ github.run_attempt }} sha=${{ github.event.pull_request.head.sha }} scope=general
         run: |
-          MAX_ATTEMPTS=6
-          SLEEP_SECONDS=10
-          BODY=""
-
-          for i in $(seq 1 "$MAX_ATTEMPTS"); do
-            BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-              | jq -r --arg header "$HEADER" --arg marker "$REVIEW_MARKER" \
-                '[.[] | select((.body // "") | contains($header) and contains($marker))] | last | .body // ""')
-
-            if [ -z "$BODY" ]; then
-              BODY=$(gh api "repos/${{ github.repository }}/issues/${{ github.event.pull_request.number }}/comments" --paginate \
-                | jq -r --arg header "$HEADER" --arg run_token "run=${{ github.run_id }}" --arg sha_token "sha=${{ github.event.pull_request.head.sha }}" \
-                  '[.[] | select((.body // "") | contains($header) and contains($run_token) and contains($sha_token))] | last | .body // ""')
+          {
+            echo "## Claude Review - General Engineering Review"
+            echo ""
+            if [ -s /tmp/review.txt ]; then
+              cat /tmp/review.txt
+            else
+              echo "No review output was produced."
             fi
+          } > /tmp/review-formatted.txt
 
-            if [ -n "$BODY" ]; then
-              echo "Found Claude review comment on attempt $i"
-              break
-            fi
+          gh pr comment ${{ github.event.pull_request.number }} --body-file /tmp/review-formatted.txt
 
-            if [ "$i" -lt "$MAX_ATTEMPTS" ]; then
-              echo "Claude review comment not found yet; sleeping ${SLEEP_SECONDS}s... (attempt $i/$MAX_ATTEMPTS)"
-              sleep "$SLEEP_SECONDS"
-            fi
-          done
-
-          if [ -z "$BODY" ]; then
-            echo "::error::Could not find Claude review output for general changes"
+      - name: Check for blocking findings
+        if: always()
+        run: |
+          if [ ! -s /tmp/review.txt ]; then
+            echo "::error::No review output was produced despite reviewable changes"
             exit 1
           fi
 
-          if echo "$BODY" | grep -qE '\[(CRITICAL|HIGH)\]'; then
+          if grep -qE '\[(CRITICAL|HIGH)\]' /tmp/review.txt; then
             echo "::error::Review found CRITICAL or HIGH severity issues"
             exit 1
           fi


### PR DESCRIPTION
## Summary

Two CI workflow fixes uncovered while testing PR #144 (run [25278577961](https://github.com/Provable-Games/summit/actions/runs/25278577961)).

### Fix 1 — Claude jobs ran but never posted comments

In `claude-code-action` v1, `prompt:` (automation) mode does **not** auto-post a PR comment the way the beta `direct_prompt:` did. Each of our four Claude review jobs ran cleanly (`is_error: false`, `--model claude-opus-4-7` confirmed), produced a review, then the polling step timed out for 60s and failed the job because no comment ever appeared.

Replace the comment-polling pattern (`gh api … | jq` with 6×10s retries and 2–4 fallback queries) with the capture-extract-post-check sequence already used by the Codex jobs:

1. `id: claude` on the action step exposes `execution_file` (Claude Code stream-JSON).
2. New `Extract review output` step pulls the final `result.result` text (or falls back to assistant text) into `/tmp/review.txt`.
3. New `Post review comment` step writes `## Claude Review - …` + body to the PR via `gh pr comment`.
4. `Check for blocking findings` greps the local file for `[CRITICAL]`/`[HIGH]`.

Net: review comments appear immediately, blocking-check is deterministic, and the 4 Claude jobs now mirror the 4 Codex jobs structurally.

### Fix 2 — `general_review` triggered on scoped-only changes

PR #144 changed only `api/README.md`, `client/README.md`, `contracts/README.md` — all inside excluded scopes — yet `claude-review-general` and `codex-review-general` ran. dorny/paths-filter v3's OR-list semantics don't reliably honor `!` negations against a leading `**` glob.

Replace:

```yaml
general_review:
  - "**"
  - "!contracts/**"
  - "!client/**"
  - "!indexer/**"
  - "!api/**"
```

with a shell step that computes `general_review` from `gh pr diff --name-only` — true iff the PR touches a file outside `contracts/`, `client/`, `indexer/`, or `api/`. The four scoped filters (`contracts_review`, `client_review`, `indexer_api_review`) continue to use paths-filter (no negations there).

## Test plan

- [ ] CI green on this PR (modifies `pr-ci.yml`, so AI reviews are gated off via `review_automation_modified` — only the deterministic jobs run)
- [ ] After merge, retest by re-running PR #144 (or push a synchronize commit). Expected: 4 Claude comments + 4 Codex comments, **no** `*-general` jobs run, `pr-ci` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow automation to improve review extraction and processing efficiency.

**Note:** This is an internal infrastructure change with no direct impact on end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->